### PR TITLE
update to 0.9.7 PKG-2618

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "uriparser" %}
-{% set version = "0.9.3" %}
+{% set version = "0.9.7" %}
 
 package:
   name: {{ name|lower }}
@@ -7,17 +7,14 @@ package:
 
 source:
   url: https://github.com/{{ name }}/{{ name }}/archive/{{ name }}-{{ version }}.tar.gz
-  sha256: 3ea184e1ef2286e54ce712364780f1b29d1c58233f7a142b11c0550a910e295c
+  sha256: 8e19250654a204af0858408b55dc78941382a8c824bf38fc7f2a95ca6e16d7a0
 
 build:
-  number: 1
-  skip: true  # [win and vc<14]
+  number: 0
 
 requirements:
   build:
     - {{ compiler('c') }}
-    # Even though uriparser is pure C, its CMakeLists.txt declares it as a C++ project
-    - {{ compiler('cxx') }}
     - cmake
     - ninja
     - pkg-config  # [linux]
@@ -36,7 +33,6 @@ about:
   license_family: BSD
   license_file: COPYING
   summary: 'RFC 3986 compliant URI parsing and handling library written in C89'
-
   description: |
     uriparser is a strictly RFC 3986 compliant URI parsing and handling
     library written in C89 ("ANSI C"). uriparser is cross-platform, fast,


### PR DESCRIPTION
Changes:
- Update to 0.9.7
- Remove cxx compiler (only needed for tests which we don't compile)

Reason: missing from s390x, needed for libkml [rebuild](https://github.com/AnacondaRecipes/libkml-feedstock/pull/3).

https://github.com/uriparser/uriparser/tree/uriparser-0.9.7